### PR TITLE
Added String as mouseWheelZoom's supported types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ const VueCroppie = {
           default: true
         },
         mouseWheelZoom: {
-          type: Boolean | String,
+          type: [Boolean, String],
           default: true
         },
         showZoomer: {

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ const VueCroppie = {
           default: true
         },
         mouseWheelZoom: {
-          type: Boolean,
+          type: Boolean | String,
           default: true
         },
         showZoomer: {


### PR DESCRIPTION
Issue: 
![screenshot from 2019-01-24 10-21-57](https://user-images.githubusercontent.com/15526434/51677803-e73a0800-1fc1-11e9-9ab9-b4712306556d.png)

I added the type String as accepted by mouseWheelZoom property, as the documentation allows.

https://foliotek.github.io/Croppie/